### PR TITLE
Allow usage of request method in subclasses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ export class API {
     );
   }
 
-  private request(
+  protected request(
     method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
     version: 1 | 2,
     path: string,


### PR DESCRIPTION
I really like the TypeScript version of API, thanks for your work 👏

I wanted to extend the src/index.ts API with a couple custom methods while avoiding a reimplemention of a request method/axios. Therefore the PR, changing API.request from private to protected to make it open for subclasses.