### PR TITLE
Remove api_key assign on axios request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,9 +50,7 @@ export class API {
     this.axios.interceptors.request.use(
       (config) => {
         let data = {
-          ...config.data,
-          api_key: this.KEY,
-          secret: this.SECRETS,
+          ...config.data
         };
         let payload = JSON.stringify(data);
 


### PR DESCRIPTION
The overwriting of key-value pairs api_key and secret during the axios request phase interferes with endpoints such as addExchangeAccount (https://github.com/3commas-io/3commas-official-api-docs/blob/master/accounts_api.md#add-exchange-account--permission-accounts_write-security-signed) and editExchangeAccount.

The said overwrite does not seem to bring any benefit to the requests and removing the overwrite does not appear to bring any harmful side-effects.